### PR TITLE
Make fully-static Go binary to work with Alpine, Ubuntu, etc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GOIMPORTS=goimports
 else
 UID:=$(shell id -u)
 DOCKER_OPTS=--rm -u $(UID) -v $(HOME):$(HOME) -e HOME -e USER=$(USER) -e USERNAME=$(USER) -w $(PWD)
-GO=docker run $(DOCKER_OPTS) -e GOARCH -e GOOS golang:$(GO-VERSION) go
+GO=docker run $(DOCKER_OPTS) -e GOARCH -e GOOS -e CGO_ENABLED golang:$(GO-VERSION) go
 GOTOOLS=docker run $(DOCKER_OPTS) jare/go-tools
 GOIMPORTS=$(GOTOOLS) goimports
 HAS_GO_IMPORTS=true


### PR DESCRIPTION
When you `USE_GO_CONTAINERS=true make build`, the resulting `build/cloud-service-broker.linux` wants the particular version of GLIBC that present at build-time in the Go container to be present at run-time. This means the resulting binary won't properly run in either Alpine or Ubuntu docker images. 

(Instead you'll see cryptic messages in Alpine about the file not being found when you run the binary even though _it's obviously right there_. I spent a couple hours trying to figure out why I couldn't `make run-broker-aws-docker` before I finally tried it with an Ubuntu image and saw more info about GLIBC_2_28 files not being present and figured out what was up.)

This change passes the `CGO_ENABLED` env var to the Go Docker image (it was ignored previously) to ensure a static binary is built.
