### PR TITLE
Fixes #60

### DIFF
--- a/azure-brokerpak/azure-storage-account.yml
+++ b/azure-brokerpak/azure-storage-account.yml
@@ -122,6 +122,10 @@ provision:
     type: boolean
     details: Skip automatic Azure provider registration, set to true if service principal being used does not have rights to register providers
     default: false       
+  - field_name: authorized_networks
+    type: array
+    details: A list of resource ids for subnets of the Azure Vnet authorized
+    default: []
   computed_inputs:
   - name: labels
     default: ${json.marshal(request.default_labels)}

--- a/azure-brokerpak/terraform/azure-storage/account-provision.tf
+++ b/azure-brokerpak/terraform/azure-storage/account-provision.tf
@@ -24,6 +24,7 @@ variable azure_client_id { type = string }
 variable azure_client_secret { type = string }
 # variable authorized_network {type = string}
 variable skip_provider_registration { type = bool }
+variable authorized_networks { type = list(string) }
 
 provider "azurerm" {
   version = "~> 2.20.0"
@@ -64,6 +65,16 @@ resource "azurerm_storage_account" "account" {
   account_kind = var.storage_account_type
 
   tags = var.labels
+}
+
+resource "azurerm_storage_account_network_rules" "account_network_rule" {
+  count = length(var.authorized_networks) != 0 ? 1 : 0
+
+  resource_group_name  = local.resource_group
+  storage_account_name = azurerm_storage_account.account.name
+
+  default_action             = "Deny"
+  virtual_network_subnet_ids = var.authorized_networks[*]
 }
 
 output primary_access_key { value = azurerm_storage_account.account.primary_access_key }

--- a/docs/azure-storage-account-plans-and-config.md
+++ b/docs/azure-storage-account-plans-and-config.md
@@ -25,6 +25,7 @@ The following parameters may be configured during service provisioning (`cf crea
 | azure_client_id | string | ID of Azure service principal to authenticate for instance creation | config file value `azure.client_id` |
 | azure_client_secret | string | Secret (password) for Azure service principal to authenticate for instance creation | config file value `azure.client_secret` |
 | skip_provider_registration | boolean | `true` to skip automatic Azure provider registration, set if service principal being used does not have rights to register providers | `false` |
+| authorized_networks | list (string) | A list of resource ids for subnets of the Azure Vnet authorized | `[]`
 
 ## Binding Credentials
 


### PR DESCRIPTION
Added a list for authorized_networks in csb-azure-storage-account. When a value is identified in authorized networks default_action is set to deny in **azure-brokerpak/terraform/azure-storage/account-provision.tf**

Documentation updated to include authorized_networks in **docs/azure-storage-account-plans-and-config.md**

authorized_networks variable added to **azure-brokerpak/azure-storage-account.yml**


