### PR TITLE
Add support for Azure SQL short term retention period.

### DIFF
--- a/azure-brokerpak/azure-mssql-db-failover.yml
+++ b/azure-brokerpak/azure-mssql-db-failover.yml
@@ -124,6 +124,12 @@ provision:
     type: string
     details: Azure sku (typically, tier [GP_S,GP,BC,HS] + family [Gen4,Gen5] + cores, e.g. GP_S_Gen4_1, GP_Gen5_8, see https://docs.microsoft.com/en-us/azure/azure-sql/database/resource-limits-vcore-single-databases) Will be computed from cores if empty.
     default: ""    
+  - field_name: short_term_retention_days
+    type: number
+    details: Retention period in days for short term retention (Point in Time Restore) policy
+    default: 7
+    constraints:
+      maximum: 35
   template_ref: terraform/azure-mssql-db-failover/provision-fog-db.tf 
   computed_inputs:
   - name: labels

--- a/azure-brokerpak/azure-mssql-db.yml
+++ b/azure-brokerpak/azure-mssql-db.yml
@@ -102,6 +102,12 @@ provision:
     type: string
     details: Azure sku (typically, tier [GP_S,GP,BC,HS] + family [Gen4,Gen5] + cores, e.g. GP_S_Gen4_1, GP_Gen5_8) Will be computed from cores if empty.
     default: ""       
+  - field_name: short_term_retention_days
+    type: number
+    details: Retention period in days for short term retention (Point in Time Restore) policy
+    default: 7
+    constraints:
+      maximum: 35
   template_ref: terraform/azure-mssql-db/provision-mssql-db.tf 
   computed_inputs:
   - name: labels

--- a/azure-brokerpak/manifest.yml
+++ b/azure-brokerpak/manifest.yml
@@ -27,8 +27,8 @@ terraform_binaries:
   version: 0.12.26
   source: https://github.com/hashicorp/terraform/archive/v0.12.26.zip  
 - name: terraform-provider-azurerm
-  version: 2.20.0
-  source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v2.20.0.zip
+  version: 2.31.0
+  source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v2.31.0.zip
 - name: terraform-provider-random
   version: 2.2.1
   source: https://releases.hashicorp.com/terraform-provider-random/2.2.1/terraform-provider-random_2.2.1_linux_amd64.zip

--- a/azure-brokerpak/terraform/azure-cosmosdb/provision-cosmosdb-sql.tf
+++ b/azure-brokerpak/terraform/azure-cosmosdb/provision-cosmosdb-sql.tf
@@ -32,7 +32,7 @@ variable labels { type = map }
 variable skip_provider_registration { type = bool }
 
 provider "azurerm" {
-  version = "~> 2.20.0"
+  version = "~> 2.31.0"
   features {}
 
   subscription_id = var.azure_subscription_id

--- a/azure-brokerpak/terraform/azure-eventhubs/azure-eventhubs-bind.tf
+++ b/azure-brokerpak/terraform/azure-eventhubs/azure-eventhubs-bind.tf
@@ -22,7 +22,7 @@ variable azure_client_secret { type = string }
 variable skip_provider_registration { type = bool }
 
 provider "azurerm" {
-  version = "~> 2.20.0"
+  version = "~> 2.31.0"
   features {}
 
   subscription_id = var.azure_subscription_id

--- a/azure-brokerpak/terraform/azure-eventhubs/azure-eventhubs.tf
+++ b/azure-brokerpak/terraform/azure-eventhubs/azure-eventhubs.tf
@@ -27,7 +27,7 @@ variable labels { type = map }
 variable skip_provider_registration { type = bool }
 
 provider "azurerm" {
-  version = "~> 2.20.0"
+  version = "~> 2.31.0"
   features {}
 
   subscription_id = var.azure_subscription_id

--- a/azure-brokerpak/terraform/azure-mongodb/azure-mongodb.tf
+++ b/azure-brokerpak/terraform/azure-mongodb/azure-mongodb.tf
@@ -35,7 +35,7 @@ variable labels { type = map }
 variable skip_provider_registration { type = bool }
 
 provider "azurerm" {
-  version = "~> 2.20.0"
+  version = "~> 2.31.0"
   features {}
 
   subscription_id = var.azure_subscription_id

--- a/azure-brokerpak/terraform/azure-mssql-failover/provision-mssql-failover.tf
+++ b/azure-brokerpak/terraform/azure-mssql-failover/provision-mssql-failover.tf
@@ -31,7 +31,7 @@ variable read_write_endpoint_failover_policy { type = string }
 variable failover_grace_minutes { type = number }
 
 provider "azurerm" {
-  version = "~> 2.20.0"
+  version = "~> 2.31.0"
   features {}
 
   subscription_id = var.azure_subscription_id

--- a/azure-brokerpak/terraform/azure-mssql-server/mssql-server-provision.tf
+++ b/azure-brokerpak/terraform/azure-mssql-server/mssql-server-provision.tf
@@ -26,7 +26,7 @@ variable authorized_network {type = string}
 variable skip_provider_registration { type = bool }
 
 provider "azurerm" {
-  version = "~> 2.20.0"
+  version = "~> 2.31.0"
   features {}
 
   subscription_id = var.azure_subscription_id

--- a/azure-brokerpak/terraform/azure-mssql/provision-mssql.tf
+++ b/azure-brokerpak/terraform/azure-mssql/provision-mssql.tf
@@ -28,7 +28,7 @@ variable authorized_network {type = string}
 variable skip_provider_registration { type = bool }
 
 provider "azurerm" {
-  version = "~> 2.20.0"
+  version = "~> 2.31.0"
   features {}
 
   subscription_id = var.azure_subscription_id

--- a/azure-brokerpak/terraform/azure-mysql/provision-mysql.tf
+++ b/azure-brokerpak/terraform/azure-mysql/provision-mysql.tf
@@ -31,7 +31,7 @@ variable tls_min_version { type = string }
 variable skip_provider_registration { type = bool }
 
 provider "azurerm" {
-  version = "~> 2.20.0"
+  version = "~> 2.31.0"
   features {}
 
   subscription_id = var.azure_subscription_id

--- a/azure-brokerpak/terraform/azure-postgres/postgres-provision.tf
+++ b/azure-brokerpak/terraform/azure-postgres/postgres-provision.tf
@@ -30,7 +30,7 @@ variable use_tls { type = bool }
 variable skip_provider_registration { type = bool }
 
 provider "azurerm" {
-  version = "~> 2.20.0"
+  version = "~> 2.31.0"
   features {}
 
   subscription_id = var.azure_subscription_id

--- a/azure-brokerpak/terraform/azure-redis/redis-provision.tf
+++ b/azure-brokerpak/terraform/azure-redis/redis-provision.tf
@@ -28,7 +28,7 @@ variable tls_min_version { type = string }
 variable maxmemory_policy { type = string }
 
 provider "azurerm" {
-  version = "~> 2.20.0"
+  version = "~> 2.31.0"
   features {}
 
   subscription_id = var.azure_subscription_id

--- a/azure-brokerpak/terraform/azure-resource-group/resource-group-provision.tf
+++ b/azure-brokerpak/terraform/azure-resource-group/resource-group-provision.tf
@@ -22,7 +22,7 @@ variable labels { type = map }
 variable skip_provider_registration { type = bool }
 
 provider "azurerm" {
-  version = "~> 2.20.0"
+  version = "~> 2.31.0"
   features {}
 
   subscription_id = var.azure_subscription_id

--- a/azure-brokerpak/terraform/azure-storage/account-provision.tf
+++ b/azure-brokerpak/terraform/azure-storage/account-provision.tf
@@ -27,7 +27,7 @@ variable skip_provider_registration { type = bool }
 variable authorized_networks { type = list(string) }
 
 provider "azurerm" {
-  version = "~> 2.20.0"
+  version = "~> 2.31.0"
   features {}
 
   subscription_id = var.azure_subscription_id

--- a/azure-brokerpak/terraform/subsume-masb-mssql-db/azure-provider.tf
+++ b/azure-brokerpak/terraform/subsume-masb-mssql-db/azure-provider.tf
@@ -19,7 +19,7 @@ variable azure_tenant_id { type = string }
 variable skip_provider_registration { type = bool }
 
 provider "azurerm" {
-  version = "~> 2.20.0"
+  version = "~> 2.31.0"
   features {}
 
   subscription_id = var.azure_subscription_id

--- a/azure-brokerpak/terraform/subsume-mssql-db/azure-provider.tf
+++ b/azure-brokerpak/terraform/subsume-mssql-db/azure-provider.tf
@@ -19,7 +19,7 @@ variable azure_tenant_id { type = string }
 variable skip_provider_registration { type = bool }
 
 provider "azurerm" {
-  version = "~> 2.20.0"
+  version = "~> 2.31.0"
   features {}
 
   subscription_id = var.azure_subscription_id


### PR DESCRIPTION
Implements: https://github.com/pivotal/cloud-service-broker/issues/100

Upgrades to Azure RM provider version 2.31.0, and switches from azurerm_sql_database to newer azurerm_mssql_database resource type which is required to support the new short_term_retention_policy configuration block.