### PR TITLE
Move TLS config to plan_inputs, MySQL backup retention, Redis firewall rules.

### DIFF
--- a/azure-brokerpak/azure-mysql.yml
+++ b/azure-brokerpak/azure-mysql.yml
@@ -44,6 +44,14 @@ plans:
     storage_gb: 20    
 provision:
   plan_inputs:
+  - field_name: use_tls
+    type: boolean
+    details: Use TLS for connection
+    default: true      
+  - field_name: tls_min_version
+    type: string
+    details: Minimum enforced TLS version. Possible values are TLSEnforcementDisabled, TLS1_0, TLS1_1 (default), and TLS1_2
+    default: TLS1_1
   user_inputs:
   - field_name: cores
     type: integer
@@ -70,14 +78,6 @@ provision:
       "5.7": MySQL v5.7
       "8.0": MySQL v8.0
     prohibit_update: true  
-  - field_name: use_tls
-    type: boolean
-    details: Use TLS for connection
-    default: true      
-  - field_name: tls_min_version
-    type: string
-    details: Minimum enforced TLS version. Possible values are TLSEnforcementDisabled, TLS1_0, TLS1_1 (default), and TLS1_2
-    default: TLS1_1
   - field_name: instance_name
     type: string
     details: Name for your MySQL instance
@@ -167,7 +167,11 @@ provision:
     type: string
     details: Azure sku (typically, tier [B,GP,MO] + family [Gen4,Gen5] + cores, e.g. B_Gen4_1, GP_Gen5_8, see https://docs.microsoft.com/en-us/azure/mysql/concepts-pricing-tiers) Will be computed from cores if empty.
     default: ""
-    prohibit_update: true  
+    prohibit_update: true
+  - field_name: backup_retention_days
+    type: integer
+    details: Backup retention days for the server, supported values are between 7 and 35 days.
+    default: 7
   computed_inputs:
   - name: labels
     default: ${json.marshal(request.default_labels)}

--- a/azure-brokerpak/azure-mysql.yml
+++ b/azure-brokerpak/azure-mysql.yml
@@ -28,6 +28,8 @@ plans:
   description: 'Mysql v5.7. Instance properties: 2 vCores, 4 GB RAM, 5 GB storage.'
   display_name: "Small"
   properties:
+    use_tls: true
+    tls_min_version: "TLS1_1"
 - name: medium
   id: 9eb836dd-4B90-4cF7-bc06-1986103802d3
   description: 'Mysql v5.7. Instance properties: 4 vCores, 20 GB RAM, 10 GB storage.'
@@ -35,6 +37,8 @@ plans:
   properties:
     cores: 4
     storage_gb: 10    
+    use_tls: true
+    tls_min_version: "TLS1_1"
 - name: large
   id: 6f8Ea44c-6840-4b0b-9068-f0cd9b17437c
   description: 'Mysql v5.7. Instance properties: 8 vCores, 80 GB RAM, 20 GB storage.'
@@ -42,6 +46,8 @@ plans:
   properties:
     cores: 8
     storage_gb: 20    
+    use_tls: true
+    tls_min_version: "TLS1_1"
 provision:
   plan_inputs:
   - field_name: use_tls

--- a/azure-brokerpak/azure-redis.yml
+++ b/azure-brokerpak/azure-redis.yml
@@ -96,6 +96,13 @@ provision:
     constraints:
       maximum: 6
       minimum: 0
+  - field_name: tls_min_version
+    type: string
+    details: Minimum enforced TLS version. Possible values are 1.0, 1.1, 1.2
+    default: "1.2"
+  - field_name: firewall_rules
+    type: array
+    details: Array of firewall rule start/end IP pairs (e.g. [["1.2.3.4", "2.3.4.5"], ["5.6.7.8", "6.7.8.9"]])
   user_inputs:
   - field_name: instance_name
     type: string
@@ -173,10 +180,6 @@ provision:
     type: boolean
     details: Skip automatic Azure provider registration, set to true if service principal being used does not have rights to register providers
     default: false       
-  - field_name: tls_min_version
-    type: string
-    details: Minimum enforced TLS version. Possible values are 1.0, 1.1, 1.2
-    default: "1.2"
   - field_name: maxmemory_policy
     type: string
     details: Max memory eviction policy. Possible values are volatile-lru (default), allkeys-lru, volatile-random, allkeys-random, volatile-ttl, noeviction

--- a/azure-brokerpak/terraform/azure-mysql/provision-mysql.tf
+++ b/azure-brokerpak/terraform/azure-mysql/provision-mysql.tf
@@ -29,6 +29,7 @@ variable authorized_network {type = string}
 variable use_tls { type = bool }
 variable tls_min_version { type = string }
 variable skip_provider_registration { type = bool }
+variable backup_retention_days { type = number }
 
 provider "azurerm" {
   version = "~> 2.33.0"
@@ -95,6 +96,7 @@ resource "azurerm_mysql_server" "instance" {
   version                          = var.mysql_version
   ssl_enforcement_enabled          = var.use_tls
   ssl_minimal_tls_version_enforced = local.tls_version
+  backup_retention_days            = var.backup_retention_days
   tags = var.labels
 }
 


### PR DESCRIPTION
Move TLS configuration from user_inputs to plan_inputs for Azure MySQL and Azure Redis.
Add support for controlling backup retention for Azure MySQL.
Add support for firewall rules for Azure Redis.