### PR TITLE
Fixes #146

### DIFF
--- a/azure-brokerpak/azure-redis.yml
+++ b/azure-brokerpak/azure-redis.yml
@@ -83,6 +83,15 @@ plans:
     capacity: 5          
     firewall_rules: []
     tls_min_version: "1.2" 
+- name: ha-P1
+  id: 2a63e092-ab5c-4804-abd6-2d951240f0f6
+  description: "A High Availability plan with 6GB cache and no failover"
+  display_name: "High Availability P1"
+  properties:
+    sku_name: Premium
+    family: P
+    capacity: 1
+    tls_min_version: "1.2"
 provision:
   plan_inputs:
   - field_name: sku_name
@@ -115,6 +124,11 @@ provision:
   - field_name: firewall_rules
     type: array
     details: Array of firewall rule start/end IP pairs (e.g. [["1.2.3.4", "2.3.4.5"], ["5.6.7.8", "6.7.8.9"]])
+    default: []
+  - field_name: subnet_id
+    type: string
+    details: The subnet in which the redis instance will be created (only for premium plan)
+    default: ""
   user_inputs:
   - field_name: instance_name
     type: string
@@ -196,6 +210,14 @@ provision:
     type: string
     details: Max memory eviction policy. Possible values are volatile-lru (default), allkeys-lru, volatile-random, allkeys-random, volatile-ttl, noeviction
     default: volatile-lru
+  - field_name: subnet_id
+    type: string
+    details: Subnet in which the Redis instances will be (only available for Premium plans)
+    default: ""
+  - field_name: firewall_rules
+    type: array
+    details: Array of start and end IPs
+    default: []
   computed_inputs:
   - name: labels
     default: ${json.marshal(request.default_labels)}

--- a/azure-brokerpak/terraform/azure-redis/redis-provision.tf
+++ b/azure-brokerpak/terraform/azure-redis/redis-provision.tf
@@ -27,6 +27,7 @@ variable skip_provider_registration { type = bool }
 variable tls_min_version { type = string }
 variable maxmemory_policy { type = string }
 variable firewall_rules { type = list(list(string)) }
+variable subnet_id { type = string }
 
 provider "azurerm" {
   version = "~> 2.33.0"
@@ -58,6 +59,7 @@ resource "azurerm_redis_cache" "redis" {
   family              = var.family
   capacity            = var.capacity
   location            = var.location
+  subnet_id	          = length(var.subnet_id) == 0 ? "" : var.subnet_id
   resource_group_name = local.resource_group
   minimum_tls_version = length(var.tls_min_version) == 0 ? "1.2" : var.tls_min_version
   tags                = var.labels

--- a/docs/redis-plans-and-config.md
+++ b/docs/redis-plans-and-config.md
@@ -64,8 +64,6 @@ The following parameters (as well as those above) may be configured at service p
 | redis_version | string | Redis version to provision (`"2.6"`, `"2.8"`, `"3.2"`, `"4.0"`, `"5.0"`) | `"5.0"`|
 | cache_size | integer | Size in GB for cache: 1,2,4,8,16,32,64,128,256 | per plan |
 | node_type | string | explicit [node type](https://aws.amazon.com/elasticache/pricing/) *overrides* `cache_size` conversion into node type per table above | | 
-| elasticache_subnet_group | string | Name of subnet to attach redis instance to, overrides *aws_vpc_id* | |
-| vpc_security_group_ids | comma delimited string | Security group ID's to assign to redis instance | |
 
 ### Azure Notes - applies to *csb-azure-redis*
 
@@ -95,6 +93,7 @@ The following parameters plan options
 | ha-small | Standard | C | 1 | 1GB | yes |
 | ha-medium | Standard | C | 3 | 6GB | yes |
 | ha-large | Standard | C | 5 | 26GB | yes |
+| ha-P1 | Premium | P | 1 | 6GB | yes
 
 
 #### Configuration Options
@@ -111,6 +110,7 @@ The following parameters (as well as those above) may be configured at service p
 | azure_client_id | string | ID of Azure service principal to authenticate for instance creation | config file value `azure.client_id` |
 | azure_client_secret | string | Secret (password) for Azure service principal to authenticate for instance creation | config file value `azure.client_secret` |
 | skip_provider_registration | boolean | `true` to skip automatic Azure provider registration, set if service principal being used does not have rights to register providers | `false` |
+| subnet_id | string | ID of the subnet in which the Redis Cache instances will be provisionned | null |
 
 #### Notes
 For consuming Azure Redis, the TLS port is used in place of the standard port.  The key for the TLS port is "tls_port".  The standard port is disabled for both the Azure Basic Plans as well as Azure High Availability Plans.


### PR DESCRIPTION
Added a string for **subnet_id** in csb-azure-redis that allow to specify in which subnet the Redis instance will be and a plan for **ha-P1** => azure-brokerpak/azure-redis.yml

Documentation updated to include the parameters **ha-P1 plan** and **subnet_id string**  in cloud-service-broker/docs/redis-plans-and-config.md

**subnet_id** variable added to azure-brokerpak/terraform/azure-redis/redis-provision.tf