### PR TITLE
TNZ-84169: Add coverity.yaml for DRS compliance

### DIFF
--- a/coverity.yaml
+++ b/coverity.yaml
@@ -1,0 +1,4 @@
+Service: cloud-service-broker
+Language: go
+Default_branch: main
+Commit: main


### PR DESCRIPTION
## Summary
* Add `coverity.yaml` to enable Coverity Static Analysis (Source Code Scanning).
* This is a requirement for GTO's DevOps Release Scorecard (DRS) for Europa compliance.

ai-assisted=yes